### PR TITLE
Add X's to mktemp file/dir name template

### DIFF
--- a/git-zeal
+++ b/git-zeal
@@ -224,8 +224,8 @@ function zeal_build()
   local -i start=$(date +%s)
   zeal_set_build_result -v start=$start "$object"
 
-  local build_dir=$(mktemp -d -t zeal)
-  local build_log=$(mktemp -t zeal-log)
+  local build_dir=$(mktemp -d -t zeal.XXXXXXXXXX)
+  local build_log=$(mktemp -t zeal-log.XXXXXXXXXX)
   git worktree add -f --detach "$build_dir" "$object" || return $?
 
   pushd "$build_dir" || return $?


### PR DESCRIPTION
Hi, awesome project! I just saw your description of it in #vim and I had to try it out.

I ran into an OS-specific issue that I've seen before involving `mktemp`:

```
git-zeal → mktemp -d -t zeal
mktemp: too few X's in template ‘zeal’

git-zeal → mktemp -d -t zealXXX
/tmp/zealpdC

git-zeal → mktemp -d -t zeal.XXXXXXXXXX
/tmp/zeal.mBm8IbNev2
```

On some versions of Ubuntu (I'm on Ubuntu 16.04), `mktemp` requires template strings to include at least 3 X's, which it replaces with random letters and digits. This PR fixes that and gets git-zeal working on my machine.

Looking forward to playing with this some more! 