### PR TITLE
Include STDERR in build logs

### DIFF
--- a/git-zeal
+++ b/git-zeal
@@ -231,7 +231,7 @@ function zeal_build()
   pushd "$build_dir" || return $?
 
   trap "zeal_clear_build_result ${object}; exit 130" SIGINT
-  ( $SHELL -c "$build_command" ) |tee "$build_log"
+  ( $SHELL -c "$build_command" ) 2>&1 |tee "$build_log"
   local -i build_exit=${PIPESTATUS[0]}
   trap - SIGINT
 


### PR DESCRIPTION
I noticed that when I ran `git zeal show-build-result --log <commit>`, I was seeing the output appear to suddenly stop, which seemed curious. I dug in and found that there was actually more output (usually in the form of a stacktrace) that was being printed to STDERR, but we're only teeing STDOUT into the logs. This PR makes it so that we tee both STDOUT and STDERR into the logs.