### PR TITLE
Add an --all option to clear-build-result

### DIFF
--- a/git-zeal
+++ b/git-zeal
@@ -3,17 +3,23 @@
 ##############################################################################
 # Build Results
 
+ZEAL_NOTES_REF=refs/notes/zeal
+
 function zeal_notes()
 {
-  git notes --ref refs/notes/zeal "$@" 2>/dev/null
+  git notes --ref $ZEAL_NOTES_REF "$@" 2>/dev/null
   return $?
 }
 
 function zeal_clear_build_result()
 {
-  local object="$1"
-  zeal_notes remove --ignore-missing "${object}^{tree}"
-  return $?
+  if [[ "$1" == "--all" ]]; then
+    git update-ref -d $ZEAL_NOTES_REF
+  else
+    local object="$1"
+    zeal_notes remove --ignore-missing "${object}^{tree}"
+    return $?
+  fi
 }
 
 function zeal_set_build_result()

--- a/git-zeal.1
+++ b/git-zeal.1
@@ -28,7 +28,7 @@ git-zeal \- Zealously run your tests (on every commit)
 \fIgit zeal\fR build [<commit>]
 \fIgit zeal\fR run
 \fIgit zeal\fR next
-\fIgit zeal\fR clear\-build\-result <commit>
+\fIgit zeal\fR clear\-build\-result [<commit>|--all]
 \fIgit zeal\fR set\-build\-result [\-\-exit <exit\-code>] [\-\-log <build-log>] <commit>
 \fIgit zeal\fR show\-build\-result [\-\-vars|\-\-log] [\-\-shell] <commit>
 .fi
@@ -93,9 +93,10 @@ If the commit which would be the next is currently being built, it is
 skipped\&.
 .RE
 .PP
-clear\-build\-result <commit>
+clear\-build\-result [<commit>|\-\-all]
 .RS 4
-Remove data about the result of building <commit>\&.
+Remove data about the result of building <commit>, or data for all build results
+in the current repo if \-\-all is supplied.\&.
 .RE
 .PP
 set\-build\-result [\-e|\-\-exit <exit\-code>] [\-l|\-\-log <build\-log>] [\-v|\-\-variable <varname>=<value>] <commit>


### PR DESCRIPTION
So I screwed up the testing setup on a project I'm working on, so there were a bunch of failed results recorded by git-zeal that didn't actually represent failing tests, and I wanted a quick way to reset and start re-testing everything. I hacked this together so I could run `git zeal clear-build-result --all` and have it remove all the results.

It doesn't seem like there is an intuitive way to just get a list of all the note objects via `git notes`... when I do `git notes --ref refs/notes/zeal list`, I get output that looks like this:

```
b0012c7ef092fea21fe6bdd6d6a5873bc2bd695b 84632c6c5e15c4222c9c9a175c2330d98bd20cf0
302131a15d53f06c2ff56b87de8d22ab3c5939c1 8dfb351f547d94348acae14fa654834d5a7d60b7
c57d3c93a0c4512ef0283376a62b8d75611ef78e b7c7878217cc6ab6fc8c58a57fcf75153de2e961
```

According to the [`git notes` docs](https://git-scm.com/docs/git-notes):

> list
> List the notes object for a given object. If no object is given, show a list of all note objects and the objects they annotate (in the format `<note object> <annotated object>`). This is the default subcommand if no subcommand is given.

I'm not even really sure what a note object vs. annotated object is, let alone be able to get a list of all the note objects. It seems like what I'm thinking of as the "note objects" are really "annotated objects" based on what I was seeing by running `git show <commit>`. But then, when I tried to remove those objects via `git notes remove <commit>`, it didn't seem to "take." When I ran `git notes --ref refs/notes/zeal` again, I still got the same output, including the objects I thought I'd removed. Also, a lot of the lines seem to refer to git objects of some kind that don't have notes attached.

So, to make a long story short, this is all very confusing, and the most effective way I found to remove all the notes is to delete the refs/notes/zeal ref via `git update-ref -d refs/notes/zeal`.

I tested this out and it works well for my purposes, but I don't want to inadvertently break some other feature in the future that might want to store something besides build results in refs/notes/zeal. I guess if we wanted to be safe, we could keep the results in a more specific ref like refs/notes/zeal-build-results or something. Then, if we ever wanted to store other stuff, we could put it in a different ref (refs/notes/zeal-something-else).

Anyway, thoughts?