### PR TITLE
clear-build-result manpage fix: escape hyphens

### DIFF
--- a/git-zeal.1
+++ b/git-zeal.1
@@ -28,7 +28,7 @@ git-zeal \- Zealously run your tests (on every commit)
 \fIgit zeal\fR build [<commit>]
 \fIgit zeal\fR run
 \fIgit zeal\fR next
-\fIgit zeal\fR clear\-build\-result [<commit>|--all]
+\fIgit zeal\fR clear\-build\-result [<commit>|\-\-all]
 \fIgit zeal\fR set\-build\-result [\-\-exit <exit\-code>] [\-\-log <build-log>] <commit>
 \fIgit zeal\fR show\-build\-result [\-\-vars|\-\-log] [\-\-shell] <commit>
 .fi


### PR DESCRIPTION
Follow-up to #5.

Does what it says on the tin.